### PR TITLE
fix: pittariコマンドの進行を正常化

### DIFF
--- a/commands/funcs/result_func.js
+++ b/commands/funcs/result_func.js
@@ -48,12 +48,12 @@ const result = function (interaction, target_scores, GOAL) {
 
     for(let nameAndScore of safe_list){
         // 順位の文字列について: ${何位か} 位  ${名前：スコア}  ${もしピッタリならPPマーク} ${もし1位なら偉業} ${3位以上なら王冠} 
-        pittariRankingStr += `${pittariRanking} 位  ${nameAndScore}  ${safe_list_only_score[pittariRanking-1]==GOAL?":piedpiper:":""} ${pittariRanking==1?":igyo:":""} ${pittariRanking<=3?":crown:":""}\n`
+        pittariRankingStr += `${pittariRanking} 位  ${nameAndScore} ${pittariRanking==1?":first_place:":""} ${pittariRanking==2?":second_place:":""} ${pittariRanking==3?":third_place:":""}\n`
         pittariRanking ++;
     }
 
     for(let nameAndScore of dobon_list){
-        dobonRankingStr += `${dobonRanking} 位  ${nameAndScore}  ${dobonRanking==1?":__~1:":":yosanoakiko:"}\n`
+        dobonRankingStr += `${dobonRanking} 位  ${nameAndScore}  ${dobonRanking==1?":skull_crossbones:":":skull:"}\n`
         dobonRanking ++;
     }
 

--- a/commands/utility/pittari.js
+++ b/commands/utility/pittari.js
@@ -210,8 +210,8 @@ module.exports = {
         target_list = []; // 参加者の名前を格納する
         target_list_copy = []; // 質問者順の決定時に使うため、target_listのコピーを用意しておく
         target_scores = {}; // 参加者のスコアを格納する
-        target_list.push("Tanaka Kumi"); // 一人でテスト時は"Tanaka Kumi", "Kato Ken"を予め入力
-        target_list.push("Kato Ken");
+        // target_list.push("Tanaka Kumi"); // 一人でテスト時は"Tanaka Kumi", "Kato Ken"を予め入力
+        // target_list.push("Kato Ken");
 
 		const add_button = new ButtonBuilder()
 			.setCustomId('add')


### PR DESCRIPTION
## 修正内容
- pittariコマンドで主催者がゲームを進行&中断できない不具合の解消
- ピッタリの人が出ると次の人の順番が飛ばされる不具合の解消
- ゲームリザルト画面でpiedpiperやigyo等の固有のスタンプが使えないため、仕方なくメダル等に置換した。